### PR TITLE
docs: add -y to npx examples in skills

### DIFF
--- a/skills/android-automation/SKILL.md
+++ b/skills/android-automation/SKILL.md
@@ -24,7 +24,7 @@ allowed-tools:
 > 3. **Allow enough time for each command to complete.** Midscene commands involve AI inference and screen interaction, which can take longer than typical shell commands. A typical command needs about 1 minute; complex `act` commands may need even longer.
 > 4. **Always report task results before finishing.** After completing the automation task, you MUST proactively summarize the results to the user — including key data found, actions completed, screenshots taken, and any relevant findings. Never silently end after the last automation step; the user expects a complete response in a single interaction.
 
-Automate Android devices using `npx @midscene/android@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
+Automate Android devices using `npx -y @midscene/android@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
 
 ## What `act` Can Do
 
@@ -82,8 +82,8 @@ If the model is not configured, ask the user to set it up. See [Model Configurat
 ### Connect to Device
 
 ```bash
-npx @midscene/android@1 connect
-npx @midscene/android@1 connect --deviceId emulator-5554
+npx -y @midscene/android@1 connect
+npx -y @midscene/android@1 connect --deviceId emulator-5554
 ```
 
 ### Launch an App or URL
@@ -91,9 +91,9 @@ npx @midscene/android@1 connect --deviceId emulator-5554
 Use the dedicated launch step when you want a deterministic starting point before the rest of the task:
 
 ```bash
-npx @midscene/android@1 launch --uri https://www.ebay.com
-npx @midscene/android@1 launch --uri com.android.settings
-npx @midscene/android@1 launch --uri com.android.settings/.Settings
+npx -y @midscene/android@1 launch --uri https://www.ebay.com
+npx -y @midscene/android@1 launch --uri com.android.settings
+npx -y @midscene/android@1 launch --uri com.android.settings/.Settings
 ```
 
 ### Run a Raw Android Shell Command
@@ -101,7 +101,7 @@ npx @midscene/android@1 launch --uri com.android.settings/.Settings
 Use this when the task needs lower-level device control that is not best expressed as a visible UI interaction:
 
 ```bash
-npx @midscene/android@1 runadbshell --command "dumpsys battery"
+npx -y @midscene/android@1 runadbshell --command "dumpsys battery"
 ```
 
 This is forwarded to `adb shell` on the connected device. In practice, the underlying command is `adb -s <deviceId> shell dumpsys battery` and some environments may also include the default ADB server port, such as `adb -P 5037 -s <deviceId> shell dumpsys battery`.
@@ -109,7 +109,7 @@ This is forwarded to `adb shell` on the connected device. In practice, the under
 ### Take Screenshot
 
 ```bash
-npx @midscene/android@1 take_screenshot
+npx -y @midscene/android@1 take_screenshot
 ```
 
 After taking a screenshot, read the saved image file to understand the current screen state before deciding the next action.
@@ -120,11 +120,11 @@ Use `act` to interact with the device and get the result. It autonomously handle
 
 ```bash
 # specific instructions
-npx @midscene/android@1 act --prompt "type hello world in the search field and press Enter"
-npx @midscene/android@1 act --prompt "long press the message bubble and tap Delete in the popup menu"
+npx -y @midscene/android@1 act --prompt "type hello world in the search field and press Enter"
+npx -y @midscene/android@1 act --prompt "long press the message bubble and tap Delete in the popup menu"
 
 # or target-driven instructions
-npx @midscene/android@1 act --prompt "open Settings and navigate to Wi-Fi settings, tell me the connected network name"
+npx -y @midscene/android@1 act --prompt "open Settings and navigate to Wi-Fi settings, tell me the connected network name"
 ```
 
 ### Use a Reference Image for Precise Targeting
@@ -132,7 +132,7 @@ npx @midscene/android@1 act --prompt "open Settings and navigate to Wi-Fi settin
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.
 
 ```bash
-npx @midscene/android@1 tap --locate '{
+npx -y @midscene/android@1 tap --locate '{
   "prompt": "tap the area contains the image",
   "images": [
     {
@@ -149,7 +149,7 @@ The same `locate` JSON shape also works for other commands that accept a `locate
 ### Disconnect
 
 ```bash
-npx @midscene/android@1 disconnect
+npx -y @midscene/android@1 disconnect
 ```
 
 ### Consume Report Files
@@ -159,8 +159,8 @@ The generated HTML report is recommended for human reading first. It includes st
 If another skill or tool needs to consume the report, first convert it with `report-tool` from the same platform CLI package. Prefer Markdown for LLM-based workflows. Use JSON when the report needs to be processed programmatically.
 
 ```bash
-npx @midscene/android@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
-npx @midscene/android@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
+npx -y @midscene/android@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
+npx -y @midscene/android@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
 ```
 
 ## Workflow Pattern
@@ -186,15 +186,15 @@ Since CLI commands are stateless between invocations, follow this pattern:
 **Example — Popup menu interaction:**
 
 ```bash
-npx @midscene/android@1 act --prompt "long press the message bubble and tap Delete in the popup menu"
-npx @midscene/android@1 take_screenshot
+npx -y @midscene/android@1 act --prompt "long press the message bubble and tap Delete in the popup menu"
+npx -y @midscene/android@1 take_screenshot
 ```
 
 **Example — Form interaction:**
 
 ```bash
-npx @midscene/android@1 act --prompt "fill in the username field with 'testuser' and the password field with 'pass123', then tap the Login button"
-npx @midscene/android@1 take_screenshot
+npx -y @midscene/android@1 act --prompt "fill in the username field with 'testuser' and the password field with 'pass123', then tap the Login button"
+npx -y @midscene/android@1 take_screenshot
 ```
 
 ## Troubleshooting

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -31,7 +31,7 @@ allowed-tools:
 > 3. **Allow enough time for each command to complete.** Midscene commands involve AI inference and screen interaction, which can take longer than typical shell commands. A typical command needs about 1 minute; complex `act` commands may need even longer.
 > 4. **Always report task results before finishing.** After completing the automation task, you MUST proactively summarize the results to the user — including key data found, actions completed, screenshots taken, and any relevant findings. Never silently end after the last automation step; the user expects a complete response in a single interaction.
 
-Automate web browsing using `npx @midscene/web@1`. By default, launches a headless Chrome via Puppeteer that **persists across CLI calls** — no session loss between commands. Also supports **CDP mode** and **Bridge mode** to connect to an existing Chrome browser. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
+Automate web browsing using `npx -y @midscene/web@1`. By default, launches a headless Chrome via Puppeteer that **persists across CLI calls** — no session loss between commands. Also supports **CDP mode** and **Bridge mode** to connect to an existing Chrome browser. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
 
 ## What `act` Can Do
 
@@ -123,10 +123,10 @@ Use CDP mode to control the user's existing Chrome browser. The default CDP endp
 Add `--cdp <ws-endpoint>` to every command:
 
 ```bash
-npx @midscene/web@1 connect --cdp ws://127.0.0.1:9222/devtools/browser --url https://example.com
-npx @midscene/web@1 act --cdp ws://127.0.0.1:9222/devtools/browser --prompt "click the button"
-npx @midscene/web@1 take_screenshot --cdp ws://127.0.0.1:9222/devtools/browser
-npx @midscene/web@1 disconnect --cdp ws://127.0.0.1:9222/devtools/browser
+npx -y @midscene/web@1 connect --cdp ws://127.0.0.1:9222/devtools/browser --url https://example.com
+npx -y @midscene/web@1 act --cdp ws://127.0.0.1:9222/devtools/browser --prompt "click the button"
+npx -y @midscene/web@1 take_screenshot --cdp ws://127.0.0.1:9222/devtools/browser
+npx -y @midscene/web@1 disconnect --cdp ws://127.0.0.1:9222/devtools/browser
 ```
 
 ### Important notes for CDP mode
@@ -141,10 +141,10 @@ npx @midscene/web@1 disconnect --cdp ws://127.0.0.1:9222/devtools/browser
 Use Bridge mode when the user explicitly mentions "bridge", "extension", or has the Midscene Chrome Extension installed. Add `--bridge` to every command:
 
 ```bash
-npx @midscene/web@1 --bridge connect --url https://example.com
-npx @midscene/web@1 --bridge act --prompt "click the button"
-npx @midscene/web@1 --bridge take_screenshot
-npx @midscene/web@1 --bridge disconnect
+npx -y @midscene/web@1 --bridge connect --url https://example.com
+npx -y @midscene/web@1 --bridge act --prompt "click the button"
+npx -y @midscene/web@1 --bridge take_screenshot
+npx -y @midscene/web@1 --bridge disconnect
 ```
 
 ### Important notes for Bridge mode
@@ -161,13 +161,13 @@ npx @midscene/web@1 --bridge disconnect
 ### Connect to a Web Page
 
 ```bash
-npx @midscene/web@1 connect --url https://example.com
+npx -y @midscene/web@1 connect --url https://example.com
 ```
 
 ### Take Screenshot
 
 ```bash
-npx @midscene/web@1 take_screenshot
+npx -y @midscene/web@1 take_screenshot
 ```
 
 After taking a screenshot, read the saved image file to understand the current page state before deciding the next action.
@@ -178,11 +178,11 @@ Use `act` to interact with the page and get the result. It autonomously handles 
 
 ```bash
 # specific instructions
-npx @midscene/web@1 act --prompt "click the Login button and fill in the email field with 'user@example.com'"
-npx @midscene/web@1 act --prompt "scroll down and click the Submit button"
+npx -y @midscene/web@1 act --prompt "click the Login button and fill in the email field with 'user@example.com'"
+npx -y @midscene/web@1 act --prompt "scroll down and click the Submit button"
 
 # or target-driven instructions
-npx @midscene/web@1 act --prompt "click the country dropdown and select Japan"
+npx -y @midscene/web@1 act --prompt "click the country dropdown and select Japan"
 ```
 
 ### Use a Reference Image for Precise Targeting
@@ -190,7 +190,7 @@ npx @midscene/web@1 act --prompt "click the country dropdown and select Japan"
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.
 
 ```bash
-npx @midscene/web@1 tap --locate '{
+npx -y @midscene/web@1 tap --locate '{
   "prompt": "tap the area contains the image",
   "images": [
     {
@@ -209,7 +209,7 @@ The same `locate` JSON shape also works for other commands that accept a `locate
 Disconnect from the page but keep the browser running:
 
 ```bash
-npx @midscene/web@1 disconnect
+npx -y @midscene/web@1 disconnect
 ```
 
 ### Close Browser
@@ -217,7 +217,7 @@ npx @midscene/web@1 disconnect
 Close the browser completely when finished (Puppeteer mode only):
 
 ```bash
-npx @midscene/web@1 close
+npx -y @midscene/web@1 close
 ```
 
 
@@ -228,8 +228,8 @@ The generated HTML report is recommended for human reading first. It includes st
 If another skill or tool needs to consume the report, first convert it with `report-tool` from the same platform CLI package. Prefer Markdown for LLM-based workflows. Use JSON when the report needs to be processed programmatically.
 
 ```bash
-npx @midscene/web@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
-npx @midscene/web@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
+npx -y @midscene/web@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
+npx -y @midscene/web@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
 ```
 
 ## Workflow Pattern
@@ -257,15 +257,15 @@ The browser **persists across CLI calls** via a background Chrome process. Follo
 **Example — Dropdown selection:**
 
 ```bash
-npx @midscene/web@1 act --prompt "click the country dropdown and select Japan"
-npx @midscene/web@1 take_screenshot
+npx -y @midscene/web@1 act --prompt "click the country dropdown and select Japan"
+npx -y @midscene/web@1 take_screenshot
 ```
 
 **Example — Form interaction:**
 
 ```bash
-npx @midscene/web@1 act --prompt "fill in the email field with 'user@example.com' and the password field with 'pass123', then click the Log In button"
-npx @midscene/web@1 take_screenshot
+npx -y @midscene/web@1 act --prompt "fill in the email field with 'user@example.com' and the password field with 'pass123', then click the Log In button"
+npx -y @midscene/web@1 take_screenshot
 ```
 
 ## Troubleshooting

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -26,7 +26,7 @@ allowed-tools:
 > 4. **Always report task results before finishing.** After completing the automation task, you MUST proactively summarize the results to the user — including key data found, actions completed, screenshots taken, and any relevant findings. Never silently end after the last automation step; the user expects a complete response in a single interaction.
 > 5. **Only minimize windows, never close them unless explicitly asked.** When you need to dismiss or get a window out of the way, minimize it instead of closing it. Do not close any app or window unless the user explicitly asks you to do so.
 
-Control your desktop (macOS, Windows, Linux) using `npx @midscene/computer@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
+Control your desktop (macOS, Windows, Linux) using `npx -y @midscene/computer@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
 
 ## What `act` Can Do
 
@@ -84,20 +84,20 @@ If the model is not configured, ask the user to set it up. See [Model Configurat
 ### Connect to Desktop
 
 ```bash
-npx @midscene/computer@1 connect
-npx @midscene/computer@1 connect --displayId <id>
+npx -y @midscene/computer@1 connect
+npx -y @midscene/computer@1 connect --displayId <id>
 ```
 
 ### List Displays
 
 ```bash
-npx @midscene/computer@1 list_displays
+npx -y @midscene/computer@1 list_displays
 ```
 
 ### Take Screenshot
 
 ```bash
-npx @midscene/computer@1 take_screenshot
+npx -y @midscene/computer@1 take_screenshot
 ```
 
 After taking a screenshot, read the saved image file to understand the current screen state before deciding the next action.
@@ -108,11 +108,11 @@ Use `act` to interact with the computer and get the result. It autonomously hand
 
 ```bash
 # specific instructions
-npx @midscene/computer@1 act --prompt "type hello world in the search field and press Enter"
-npx @midscene/computer@1 act --prompt "drag the file icon to the Trash"
+npx -y @midscene/computer@1 act --prompt "type hello world in the search field and press Enter"
+npx -y @midscene/computer@1 act --prompt "drag the file icon to the Trash"
 
 # or target-driven instructions
-npx @midscene/computer@1 act --prompt "search for the weather in Shanghai using the Chrome browser, tell me the result"
+npx -y @midscene/computer@1 act --prompt "search for the weather in Shanghai using the Chrome browser, tell me the result"
 ```
 
 ### Use a Reference Image for Precise Targeting
@@ -120,7 +120,7 @@ npx @midscene/computer@1 act --prompt "search for the weather in Shanghai using 
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.
 
 ```bash
-npx @midscene/computer@1 tap --locate '{
+npx -y @midscene/computer@1 tap --locate '{
   "prompt": "tap the area contains the image",
   "images": [
     {
@@ -137,7 +137,7 @@ The same `locate` JSON shape also works for other commands that accept a `locate
 ### Disconnect
 
 ```bash
-npx @midscene/computer@1 disconnect
+npx -y @midscene/computer@1 disconnect
 ```
 
 ### Consume Report Files
@@ -147,8 +147,8 @@ The generated HTML report is recommended for human reading first. It includes st
 If another skill or tool needs to consume the report, first convert it with `report-tool` from the same platform CLI package. Prefer Markdown for LLM-based workflows. Use JSON when the report needs to be processed programmatically.
 
 ```bash
-npx @midscene/computer@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
-npx @midscene/computer@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
+npx -y @midscene/computer@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
+npx -y @midscene/computer@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
 ```
 
 ## Workflow Pattern
@@ -182,15 +182,15 @@ Since CLI commands are stateless between invocations, follow this pattern:
 **Example — Context menu interaction:**
 
 ```bash
-npx @midscene/computer@1 act --prompt "right-click the file icon and select Delete from the context menu"
-npx @midscene/computer@1 take_screenshot
+npx -y @midscene/computer@1 act --prompt "right-click the file icon and select Delete from the context menu"
+npx -y @midscene/computer@1 take_screenshot
 ```
 
 **Example — Dropdown menu:**
 
 ```bash
-npx @midscene/computer@1 act --prompt "open the File menu and click New Window"
-npx @midscene/computer@1 take_screenshot
+npx -y @midscene/computer@1 act --prompt "open the File menu and click New Window"
+npx -y @midscene/computer@1 take_screenshot
 ```
 
 

--- a/skills/harmony-automation/SKILL.md
+++ b/skills/harmony-automation/SKILL.md
@@ -23,7 +23,7 @@ allowed-tools:
 > 2. **Run only one midscene command at a time.** Wait for the previous command to finish, read the screenshot, then decide the next action. Never chain multiple commands together.
 > 3. **Allow enough time for each command to complete.** Midscene commands involve AI inference and screen interaction, which can take longer than typical shell commands. A typical command needs about 1 minute; complex `act` commands may need even longer.
 
-Automate HarmonyOS NEXT devices using `npx @midscene/harmony@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
+Automate HarmonyOS NEXT devices using `npx -y @midscene/harmony@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
 
 ## What `act` Can Do
 
@@ -95,8 +95,8 @@ hdc list targets
 ### Connect to Device
 
 ```bash
-npx @midscene/harmony@1 connect
-npx @midscene/harmony@1 connect --deviceId 0123456789ABCDEF
+npx -y @midscene/harmony@1 connect
+npx -y @midscene/harmony@1 connect --deviceId 0123456789ABCDEF
 ```
 
 ### Launch an App or URL
@@ -104,9 +104,9 @@ npx @midscene/harmony@1 connect --deviceId 0123456789ABCDEF
 Use the dedicated launch step when you want a deterministic starting point before the rest of the task:
 
 ```bash
-npx @midscene/harmony@1 launch --uri com.huawei.hmos.settings
-npx @midscene/harmony@1 launch --uri com.huawei.hmos.camera
-npx @midscene/harmony@1 launch --uri https://www.example.com
+npx -y @midscene/harmony@1 launch --uri com.huawei.hmos.settings
+npx -y @midscene/harmony@1 launch --uri com.huawei.hmos.camera
+npx -y @midscene/harmony@1 launch --uri https://www.example.com
 ```
 
 ### Run a Raw HarmonyOS Shell Command
@@ -114,7 +114,7 @@ npx @midscene/harmony@1 launch --uri https://www.example.com
 Use this when the task needs lower-level device control that is not best expressed as a visible UI interaction:
 
 ```bash
-npx @midscene/harmony@1 runhdcshell --command "hidumper -s RenderService -a screen"
+npx -y @midscene/harmony@1 runhdcshell --command "hidumper -s RenderService -a screen"
 ```
 
 This is forwarded to `hdc shell` on the connected device. In practice, the underlying command is `hdc -t <deviceId> shell hidumper -s RenderService -a screen`.
@@ -122,7 +122,7 @@ This is forwarded to `hdc shell` on the connected device. In practice, the under
 ### Take Screenshot
 
 ```bash
-npx @midscene/harmony@1 take_screenshot
+npx -y @midscene/harmony@1 take_screenshot
 ```
 
 After taking a screenshot, read the saved image file to understand the current screen state before deciding the next action.
@@ -133,11 +133,11 @@ Use `act` to interact with the device and get the result. It autonomously handle
 
 ```bash
 # specific instructions
-npx @midscene/harmony@1 act --prompt "type hello world in the search field and press Enter"
-npx @midscene/harmony@1 act --prompt "long press the message bubble and tap Delete in the popup menu"
+npx -y @midscene/harmony@1 act --prompt "type hello world in the search field and press Enter"
+npx -y @midscene/harmony@1 act --prompt "long press the message bubble and tap Delete in the popup menu"
 
 # or target-driven instructions
-npx @midscene/harmony@1 act --prompt "open Settings and navigate to Wi-Fi settings, tell me the connected network name"
+npx -y @midscene/harmony@1 act --prompt "open Settings and navigate to Wi-Fi settings, tell me the connected network name"
 ```
 
 ### Use a Reference Image for Precise Targeting
@@ -145,7 +145,7 @@ npx @midscene/harmony@1 act --prompt "open Settings and navigate to Wi-Fi settin
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.
 
 ```bash
-npx @midscene/harmony@1 tap --locate '{
+npx -y @midscene/harmony@1 tap --locate '{
   "prompt": "tap the area contains the image",
   "images": [
     {
@@ -162,7 +162,7 @@ The same `locate` JSON shape also works for other commands that accept a `locate
 ### Disconnect
 
 ```bash
-npx @midscene/harmony@1 disconnect
+npx -y @midscene/harmony@1 disconnect
 ```
 
 ### Consume Report Files
@@ -172,8 +172,8 @@ The generated HTML report is recommended for human reading first. It includes st
 If another skill or tool needs to consume the report, first convert it with `report-tool` from the same platform CLI package. Prefer Markdown for LLM-based workflows. Use JSON when the report needs to be processed programmatically.
 
 ```bash
-npx @midscene/harmony@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
-npx @midscene/harmony@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
+npx -y @midscene/harmony@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
+npx -y @midscene/harmony@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
 ```
 
 ## Workflow Pattern
@@ -199,18 +199,18 @@ Since CLI commands are stateless between invocations, follow this pattern:
 
 ```bash
 hdc shell aa start -a EntryAbility -b com.huawei.hmos.settings
-npx @midscene/harmony@1 connect
-npx @midscene/harmony@1 take_screenshot
-npx @midscene/harmony@1 act --prompt "scroll down the settings list and tap About device"
-npx @midscene/harmony@1 take_screenshot
-npx @midscene/harmony@1 disconnect
+npx -y @midscene/harmony@1 connect
+npx -y @midscene/harmony@1 take_screenshot
+npx -y @midscene/harmony@1 act --prompt "scroll down the settings list and tap About device"
+npx -y @midscene/harmony@1 take_screenshot
+npx -y @midscene/harmony@1 disconnect
 ```
 
 **Example — Form interaction:**
 
 ```bash
-npx @midscene/harmony@1 act --prompt "fill in the username field with 'testuser' and the password field with 'pass123', then tap the Login button"
-npx @midscene/harmony@1 take_screenshot
+npx -y @midscene/harmony@1 act --prompt "fill in the username field with 'testuser' and the password field with 'pass123', then tap the Login button"
+npx -y @midscene/harmony@1 take_screenshot
 ```
 
 ## Common HarmonyOS Bundle Names

--- a/skills/ios-automation/SKILL.md
+++ b/skills/ios-automation/SKILL.md
@@ -23,7 +23,7 @@ allowed-tools:
 > 3. **Allow enough time for each command to complete.** Midscene commands involve AI inference and screen interaction, which can take longer than typical shell commands. A typical command needs about 1 minute; complex `act` commands may need even longer.
 > 4. **Always report task results before finishing.** After completing the automation task, you MUST proactively summarize the results to the user — including key data found, actions completed, screenshots taken, and any relevant findings. Never silently end after the last automation step; the user expects a complete response in a single interaction.
 
-Automate iOS devices using `npx @midscene/ios@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
+Automate iOS devices using `npx -y @midscene/ios@1`. Each CLI command maps directly to an MCP tool — you (the AI agent) act as the brain, deciding which actions to take based on screenshots.
 
 ## What `act` Can Do
 
@@ -81,7 +81,7 @@ If the model is not configured, ask the user to set it up. See [Model Configurat
 ### Connect to Device
 
 ```bash
-npx @midscene/ios@1 connect
+npx -y @midscene/ios@1 connect
 ```
 
 ### Launch an App, URL, or Deep Link
@@ -93,7 +93,7 @@ Use the built-in launch capability when you want to start from a known app or ro
 Use this when the task needs lower-level device control instead of a normal visible UI interaction:
 
 ```bash
-npx @midscene/ios@1 runwdarequest --method GET --endpoint /wda/screen
+npx -y @midscene/ios@1 runwdarequest --method GET --endpoint /wda/screen
 ```
 
 This does not run an ADB command. On iOS, the underlying operation is an HTTP request to WebDriverAgent, typically `GET http://<wdaHost>:<wdaPort>/session/<sessionId>/wda/screen`.
@@ -101,7 +101,7 @@ This does not run an ADB command. On iOS, the underlying operation is an HTTP re
 ### Take Screenshot
 
 ```bash
-npx @midscene/ios@1 take_screenshot
+npx -y @midscene/ios@1 take_screenshot
 ```
 
 After taking a screenshot, read the saved image file to understand the current screen state before deciding the next action.
@@ -112,11 +112,11 @@ Use `act` to interact with the device and get the result. It autonomously handle
 
 ```bash
 # specific instructions
-npx @midscene/ios@1 act --prompt "type hello world in the search field and press Enter"
-npx @midscene/ios@1 act --prompt "tap Delete, then confirm in the alert dialog"
+npx -y @midscene/ios@1 act --prompt "type hello world in the search field and press Enter"
+npx -y @midscene/ios@1 act --prompt "tap Delete, then confirm in the alert dialog"
 
 # or target-driven instructions
-npx @midscene/ios@1 act --prompt "open Settings and navigate to Wi-Fi, tell me the connected network name"
+npx -y @midscene/ios@1 act --prompt "open Settings and navigate to Wi-Fi, tell me the connected network name"
 ```
 
 ### Use a Reference Image for Precise Targeting
@@ -124,7 +124,7 @@ npx @midscene/ios@1 act --prompt "open Settings and navigate to Wi-Fi, tell me t
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.
 
 ```bash
-npx @midscene/ios@1 tap --locate '{
+npx -y @midscene/ios@1 tap --locate '{
   "prompt": "tap the area contains the image",
   "images": [
     {
@@ -141,7 +141,7 @@ The same `locate` JSON shape also works for other commands that accept a `locate
 ### Disconnect
 
 ```bash
-npx @midscene/ios@1 disconnect
+npx -y @midscene/ios@1 disconnect
 ```
 
 ### Consume Report Files
@@ -151,8 +151,8 @@ The generated HTML report is recommended for human reading first. It includes st
 If another skill or tool needs to consume the report, first convert it with `report-tool` from the same platform CLI package. Prefer Markdown for LLM-based workflows. Use JSON when the report needs to be processed programmatically.
 
 ```bash
-npx @midscene/ios@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
-npx @midscene/ios@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
+npx -y @midscene/ios@1 report-tool --action to-markdown --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-markdown
+npx -y @midscene/ios@1 report-tool --action split --htmlPath ./midscene_run/report/.../index.html --outputDir ./output-data
 ```
 
 ## Workflow Pattern
@@ -177,15 +177,15 @@ Since CLI commands are stateless between invocations, follow this pattern:
 **Example — Alert dialog interaction:**
 
 ```bash
-npx @midscene/ios@1 act --prompt "tap the Delete button and confirm in the alert dialog"
-npx @midscene/ios@1 take_screenshot
+npx -y @midscene/ios@1 act --prompt "tap the Delete button and confirm in the alert dialog"
+npx -y @midscene/ios@1 take_screenshot
 ```
 
 **Example — Form interaction:**
 
 ```bash
-npx @midscene/ios@1 act --prompt "fill in the username field with 'testuser' and the password field with 'pass123', then tap the Login button"
-npx @midscene/ios@1 take_screenshot
+npx -y @midscene/ios@1 act --prompt "fill in the username field with 'testuser' and the password field with 'pass123', then tap the Login button"
+npx -y @midscene/ios@1 take_screenshot
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- add `-y` to the `npx` examples in the Android, Browser, Computer, HarmonyOS, and iOS skill docs
- update both inline command references and fenced command examples so the documented flows stay non-interactive

## Why
Some `npx` commands can prompt for confirmation before running the package. These skill documents are meant to be followed directly during automation workflows, so the extra prompt is undesirable.

## Impact
This is a documentation-only change. Users following these examples can run the commands without an extra confirmation step.

## Validation
- `rg -n -P '\bnpx\b(?! -y)' skills`
- `git diff --check`