### PR TITLE
docs(computer): document RDP mode in computer-automation skill

### DIFF
--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -112,16 +112,26 @@ All RDP options for `connect` (RDP mode is activated when `--host` is set; the o
 - `--security-protocol <auto|tls|nla|rdp>` — Security protocol negotiation. Defaults to `auto`.
 - `--ignore-certificate` — Skip TLS certificate validation. Use only for trusted dev hosts with self-signed certs.
 - `--admin-session` — Attach to the admin/console session (equivalent to `mstsc /admin`).
-- `--desktop-width <px>` and `--desktop-height <px>` — Request a specific remote desktop resolution.
+- `--desktop-width <px>` and `--desktop-height <px>` — **Request** a specific remote desktop resolution. The actual size is whatever the RDP server negotiates back; e.g. requesting `1024x768` against a host that pins `1280x720` will land on `1280x720`. Confirm the negotiated size with `listdisplays --host ... --username ... --password ...` after connect.
 
 Notes specific to RDP mode:
 
-- `--displayId` and `--headless` are **ignored** in RDP mode. A connected RDP session always exposes a single virtual display matching the negotiated `desktopWidth`/`desktopHeight`.
-- `computer_list_displays` enumerates **local** displays. Don't rely on it after an RDP connect; the RDP session reports its size through `connect`'s success output instead.
+- `--displayId` and `--headless` are **ignored** in RDP mode. A connected RDP session always exposes a single virtual display whose size is whatever the server negotiated.
+- Two display-listing commands exist and behave differently — pick the right one:
+  - `list_displays` (with underscore, platform tool) — enumerates **local** physical displays only. Does not accept RDP flags. Useless after an RDP connect.
+  - `listdisplays` (no underscore, action tool) — accepts the same RDP flags as `connect`/`take_screenshot`/etc. In RDP mode it returns the negotiated virtual display, e.g. `[{ "id": "...", "name": "RDP 10.70.86.26:3389 (1280x720)", "primary": true }]`. Use this to verify the actual resolution.
 - The RDP transport uses a native helper binary shipped inside `@midscene/computer`. If you see `RDP helper binary not found` errors, the optional `bin/<platform>/rdp-helper` was stripped from your install — reinstall the package or unpack a fresh tarball.
 - Treat RDP credentials as secrets: do not commit `.env` files containing `--password` to the repo; prefer `export RDP_PASSWORD=...` in the current shell and reference it as `--password "$RDP_PASSWORD"`.
+- **Latency expectations**: every CLI invocation is a fresh node process, so each command re-establishes the RDP session. Budget roughly:
+  - `connect` / `take_screenshot` / `keyboardpress` / `scroll`: ~5 s (node startup + RDP TLS+NLA handshake + first frame).
+  - `act` / `assert` / `tap --locate`: ~5 s + AI inference + any planned sub-actions; expect 8–20 s end-to-end for typical interactions.
+  - The RDP handshake itself is ~700 ms; the rest is unavoidable cold-start cost in the CLI shape.
+- **Connect failure diagnostics**: when `connect` fails, the first line of stderr is the actionable error (e.g. `connect_failed: Failed to connect to RDP server: ERRCONNECT_LOGON_FAILURE: Logon failed.`). The subsequent stack trace is diagnostic noise — read the first line, then check credentials/network. Common `ERRCONNECT_*` causes:
+  - `LOGON_FAILURE` — bad username/password/domain.
+  - `CONNECT_TRANSPORT_FAILED` — host unreachable or RDP port blocked. Verify with `nc -zv <host> 3389`.
+  - `TLS_CONNECT_FAILED` — TLS handshake rejected. Try `--ignore-certificate` for self-signed dev hosts, or pin `--security-protocol nla`.
 
-After `connect --host ...` succeeds, the rest of the workflow (`act`, `tap --locate`, `assert`, `take_screenshot`, `report-tool`, `disconnect`) is identical to local mode.
+After `connect --host ...` succeeds, the rest of the workflow (`act`, `tap --locate`, `assert`, `take_screenshot`, `listdisplays`, `report-tool`, `disconnect`) is identical to local mode — just remember to pass the same `--host`/`--username`/`--password`/`--ignore-certificate` flags to every subsequent command, since each CLI invocation is stateless and reconnects.
 
 ### List Displays
 

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: desktop-computer-automation
 description: |
-  Vision-driven desktop automation using Midscene. Control your desktop (macOS, Windows, Linux) with natural language commands.
+  Vision-driven desktop automation using Midscene. Control your local desktop (macOS, Windows, Linux) or a remote Windows desktop over RDP with natural language commands.
   Operates entirely from screenshots — no DOM or accessibility labels required. Can interact with all visible elements on screen regardless of technology stack.
 
-  ⚠️ Takes over the user's real mouse and keyboard. For web apps, prefer "Browser Automation" instead.
-  Only use this for desktop-native apps (Electron, Qt, native macOS/Windows/Linux) that cannot run in a browser.
+  ⚠️ In local mode this takes over the user's real mouse and keyboard. For web apps, prefer "Browser Automation" instead.
+  Only use this for desktop-native apps (Electron, Qt, native macOS/Windows/Linux) that cannot run in a browser, or for driving a remote Windows host via RDP.
 
   Triggers: open app, press key, desktop, computer, click on screen, type text, screenshot desktop,
   launch application, switch window, desktop automation, control computer, mouse click, keyboard shortcut,
-  screen capture, find on screen, read screen, verify window, close app, test Electron app
+  screen capture, find on screen, read screen, verify window, close app, test Electron app,
+  rdp, remote desktop, windows server, connect via rdp
 
   Powered by Midscene.js (https://midscenejs.com)
 allowed-tools:
@@ -87,6 +88,40 @@ If the model is not configured, ask the user to set it up. See [Model Configurat
 npx -y @midscene/computer@1 connect
 npx -y @midscene/computer@1 connect --displayId <id>
 ```
+
+### Connect via RDP
+
+Use RDP mode to drive a **remote Windows desktop** instead of the local machine. Providing `--host` switches `connect` to RDP and routes every subsequent command (`act`, `tap`, `take_screenshot`, `assert`, `disconnect`) through the RDP helper binary bundled with `@midscene/computer`. The local mouse/keyboard is **not** touched.
+
+Minimum example:
+
+```bash
+npx -y @midscene/computer@1 connect \
+  --host rdp.example.com \
+  --username Administrator \
+  --password "$RDP_PASSWORD"
+```
+
+All RDP options for `connect` (RDP mode is activated when `--host` is set; the other flags are optional):
+
+- `--host <fqdn-or-ip>` — RDP host. Required to enter RDP mode.
+- `--port <number>` — RDP port (default `3389`).
+- `--username <user>` — RDP user account.
+- `--password <secret>` — RDP password. Prefer reading from an environment variable, secrets manager, or interactive prompt; never paste it into a shared transcript.
+- `--domain <domain>` — Active Directory / NTLM domain.
+- `--security-protocol <auto|tls|nla|rdp>` — Security protocol negotiation. Defaults to `auto`.
+- `--ignore-certificate` — Skip TLS certificate validation. Use only for trusted dev hosts with self-signed certs.
+- `--admin-session` — Attach to the admin/console session (equivalent to `mstsc /admin`).
+- `--desktop-width <px>` and `--desktop-height <px>` — Request a specific remote desktop resolution.
+
+Notes specific to RDP mode:
+
+- `--displayId` and `--headless` are **ignored** in RDP mode. A connected RDP session always exposes a single virtual display matching the negotiated `desktopWidth`/`desktopHeight`.
+- `computer_list_displays` enumerates **local** displays. Don't rely on it after an RDP connect; the RDP session reports its size through `connect`'s success output instead.
+- The RDP transport uses a native helper binary shipped inside `@midscene/computer`. If you see `RDP helper binary not found` errors, the optional `bin/<platform>/rdp-helper` was stripped from your install — reinstall the package or unpack a fresh tarball.
+- Treat RDP credentials as secrets: do not commit `.env` files containing `--password` to the repo; prefer `export RDP_PASSWORD=...` in the current shell and reference it as `--password "$RDP_PASSWORD"`.
+
+After `connect --host ...` succeeds, the rest of the workflow (`act`, `tap --locate`, `assert`, `take_screenshot`, `report-tool`, `disconnect`) is identical to local mode.
 
 ### List Displays
 


### PR DESCRIPTION
## Summary

- Add a "Connect via RDP" subsection right after "Connect to Desktop" in `skills/computer-automation/SKILL.md`, with a minimal `connect --host ...` example and a complete option reference (`--host`, `--port`, `--username`, `--password`, `--domain`, `--security-protocol`, `--ignore-certificate`, `--admin-session`, `--desktop-width`, `--desktop-height`).
- Document mode-specific behavior: `--displayId` / `--headless` are ignored under RDP, `computer_list_displays` keeps listing local displays, the helper binary requirement, and credential hygiene (use env vars, don't commit passwords).
- Refresh the SKILL.md frontmatter `description` and triggers so phrases like "rdp", "remote desktop", "windows server", and "connect via rdp" route to this skill. Still inside the 1200-char budget (1017/1200 per `scripts/check-skill-description-length.mjs`).

## Why

`@midscene/computer` now exposes RDP flags through `connect` (see web-infra-dev/midscene#2466). Without a matching skill doc, agents would not know that RDP mode exists or how to opt in, so this PR is the user-facing half of that change.

## Test plan

- [x] `node scripts/check-skill-description-length.mjs` (all skills under limit, computer-automation at 1017/1200)
- [x] Visual review of the new "Connect via RDP" subsection