### PR TITLE
docs(skills): document assert --images on platform CLIs

### DIFF
--- a/skills/android-automation/SKILL.md
+++ b/skills/android-automation/SKILL.md
@@ -137,18 +137,26 @@ npx -y @midscene/android@1 assert --prompt "the settings screen shows Wi-Fi and 
 npx -y @midscene/android@1 assert --deviceId emulator-5554 --prompt "the app shows a successful login message"
 ```
 
-When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/android@1.9.0+`.
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/android@1.9.0+`.
 
 ```bash
 npx -y @midscene/android@1 assert \
   --prompt "the visible app icon matches the supplied reference image" \
-  --images '[{"name":"icon","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --image "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png" \
+  --image-name "icon" \
   --convertHttpImage2Base64 true
 
 # or with a local file
 npx -y @midscene/android@1 assert \
   --prompt "the header on screen matches the local screenshot" \
-  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+  --image "./fixtures/header.png" \
+  --image-name "header"
+
+# multiple reference images — pair --image and --image-name by order
+npx -y @midscene/android@1 assert \
+  --prompt "the screen shows both the app icon and the header" \
+  --image "./fixtures/icon.png"   --image-name "icon" \
+  --image "./fixtures/header.png" --image-name "header"
 ```
 
 ### Use a Reference Image for Precise Targeting

--- a/skills/android-automation/SKILL.md
+++ b/skills/android-automation/SKILL.md
@@ -137,6 +137,20 @@ npx -y @midscene/android@1 assert --prompt "the settings screen shows Wi-Fi and 
 npx -y @midscene/android@1 assert --deviceId emulator-5554 --prompt "the app shows a successful login message"
 ```
 
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/android@1.9.0+`.
+
+```bash
+npx -y @midscene/android@1 assert \
+  --prompt "the visible app icon matches the supplied reference image" \
+  --images '[{"name":"icon","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --convertHttpImage2Base64 true
+
+# or with a local file
+npx -y @midscene/android@1 assert \
+  --prompt "the header on screen matches the local screenshot" \
+  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+```
+
 ### Use a Reference Image for Precise Targeting
 
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -201,18 +201,26 @@ npx -y @midscene/web@1 assert --cdp ws://127.0.0.1:9222/devtools/browser --promp
 npx -y @midscene/web@1 --bridge assert --prompt "the profile page shows the user's avatar"
 ```
 
-When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/web@1.9.0+`.
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/web@1.9.0+`.
 
 ```bash
 npx -y @midscene/web@1 assert \
   --prompt "the page shows the same logo as the reference image" \
-  --images '[{"name":"logo","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --image "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png" \
+  --image-name "logo" \
   --convertHttpImage2Base64 true
 
 # or with a local file
 npx -y @midscene/web@1 assert \
   --prompt "the visible header matches the supplied screenshot" \
-  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+  --image "./fixtures/header.png" \
+  --image-name "header"
+
+# multiple reference images — pair --image and --image-name by order
+npx -y @midscene/web@1 assert \
+  --prompt "the page shows both the logo and the header" \
+  --image "./fixtures/logo.png"   --image-name "logo" \
+  --image "./fixtures/header.png" --image-name "header"
 ```
 
 ### Use a Reference Image for Precise Targeting

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -201,6 +201,20 @@ npx -y @midscene/web@1 assert --cdp ws://127.0.0.1:9222/devtools/browser --promp
 npx -y @midscene/web@1 --bridge assert --prompt "the profile page shows the user's avatar"
 ```
 
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/web@1.9.0+`.
+
+```bash
+npx -y @midscene/web@1 assert \
+  --prompt "the page shows the same logo as the reference image" \
+  --images '[{"name":"logo","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --convertHttpImage2Base64 true
+
+# or with a local file
+npx -y @midscene/web@1 assert \
+  --prompt "the visible header matches the supplied screenshot" \
+  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+```
+
 ### Use a Reference Image for Precise Targeting
 
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -170,18 +170,26 @@ npx -y @midscene/computer@1 assert --prompt "the active window shows a saved con
 npx -y @midscene/computer@1 assert --displayId 1 --prompt "the file picker is open"
 ```
 
-When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/computer@1.9.0+`.
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/computer@1.9.0+`.
 
 ```bash
 npx -y @midscene/computer@1 assert \
   --prompt "the active window matches the supplied reference screenshot" \
-  --images '[{"name":"reference","url":"https://example.com/reference.png"}]' \
+  --image "https://example.com/reference.png" \
+  --image-name "reference" \
   --convertHttpImage2Base64 true
 
 # or with a local file
 npx -y @midscene/computer@1 assert \
   --prompt "the visible icon matches the supplied logo" \
-  --images '[{"name":"logo","url":"./fixtures/logo.png"}]'
+  --image "./fixtures/logo.png" \
+  --image-name "logo"
+
+# multiple reference images — pair --image and --image-name by order
+npx -y @midscene/computer@1 assert \
+  --prompt "the active window matches both the icon and the logo" \
+  --image "./fixtures/icon.png" --image-name "icon" \
+  --image "./fixtures/logo.png" --image-name "logo"
 ```
 
 ### Use a Reference Image for Precise Targeting

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -170,6 +170,20 @@ npx -y @midscene/computer@1 assert --prompt "the active window shows a saved con
 npx -y @midscene/computer@1 assert --displayId 1 --prompt "the file picker is open"
 ```
 
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/computer@1.9.0+`.
+
+```bash
+npx -y @midscene/computer@1 assert \
+  --prompt "the active window matches the supplied reference screenshot" \
+  --images '[{"name":"reference","url":"https://example.com/reference.png"}]' \
+  --convertHttpImage2Base64 true
+
+# or with a local file
+npx -y @midscene/computer@1 assert \
+  --prompt "the visible icon matches the supplied logo" \
+  --images '[{"name":"logo","url":"./fixtures/logo.png"}]'
+```
+
 ### Use a Reference Image for Precise Targeting
 
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.

--- a/skills/harmony-automation/SKILL.md
+++ b/skills/harmony-automation/SKILL.md
@@ -150,6 +150,20 @@ npx -y @midscene/harmony@1 assert --prompt "the settings screen shows Wi-Fi and 
 npx -y @midscene/harmony@1 assert --deviceId 0123456789ABCDEF --prompt "the app shows a successful login message"
 ```
 
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/harmony@1.9.0+`.
+
+```bash
+npx -y @midscene/harmony@1 assert \
+  --prompt "the visible app icon matches the supplied reference image" \
+  --images '[{"name":"icon","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --convertHttpImage2Base64 true
+
+# or with a local file
+npx -y @midscene/harmony@1 assert \
+  --prompt "the header on screen matches the local screenshot" \
+  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+```
+
 ### Use a Reference Image for Precise Targeting
 
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.

--- a/skills/harmony-automation/SKILL.md
+++ b/skills/harmony-automation/SKILL.md
@@ -150,18 +150,26 @@ npx -y @midscene/harmony@1 assert --prompt "the settings screen shows Wi-Fi and 
 npx -y @midscene/harmony@1 assert --deviceId 0123456789ABCDEF --prompt "the app shows a successful login message"
 ```
 
-When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/harmony@1.9.0+`.
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/harmony@1.9.0+`.
 
 ```bash
 npx -y @midscene/harmony@1 assert \
   --prompt "the visible app icon matches the supplied reference image" \
-  --images '[{"name":"icon","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --image "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png" \
+  --image-name "icon" \
   --convertHttpImage2Base64 true
 
 # or with a local file
 npx -y @midscene/harmony@1 assert \
   --prompt "the header on screen matches the local screenshot" \
-  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+  --image "./fixtures/header.png" \
+  --image-name "header"
+
+# multiple reference images — pair --image and --image-name by order
+npx -y @midscene/harmony@1 assert \
+  --prompt "the screen shows both the app icon and the header" \
+  --image "./fixtures/icon.png"   --image-name "icon" \
+  --image "./fixtures/header.png" --image-name "header"
 ```
 
 ### Use a Reference Image for Precise Targeting

--- a/skills/ios-automation/SKILL.md
+++ b/skills/ios-automation/SKILL.md
@@ -138,6 +138,20 @@ npx -y @midscene/ios@1 assert --prompt "there is a login button visible"
 npx -y @midscene/ios@1 assert --prompt "the settings screen shows Wi-Fi and Bluetooth options"
 ```
 
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/ios@1.9.0+`.
+
+```bash
+npx -y @midscene/ios@1 assert \
+  --prompt "the visible app icon matches the supplied reference image" \
+  --images '[{"name":"icon","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --convertHttpImage2Base64 true
+
+# or with a local file
+npx -y @midscene/ios@1 assert \
+  --prompt "the header on screen matches the local screenshot" \
+  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+```
+
 ### Use a Reference Image for Precise Targeting
 
 When the user provides a screenshot, icon, logo, or reference image and wants an exact visual match, prefer `tap --locate` instead of a generic `act --prompt`. Pass `--locate` as JSON. The `prompt` describes the target, `images` supplies named reference images, and `convertHttpImage2Base64: true` is useful when the image URL may not be directly accessible to the model.

--- a/skills/ios-automation/SKILL.md
+++ b/skills/ios-automation/SKILL.md
@@ -138,18 +138,26 @@ npx -y @midscene/ios@1 assert --prompt "there is a login button visible"
 npx -y @midscene/ios@1 assert --prompt "the settings screen shows Wi-Fi and Bluetooth options"
 ```
 
-When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--images` with a JSON array. Each `url` may be an http(s) link, a `data:` URI, or a local file path. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/ios@1.9.0+`.
+When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/ios@1.9.0+`.
 
 ```bash
 npx -y @midscene/ios@1 assert \
   --prompt "the visible app icon matches the supplied reference image" \
-  --images '[{"name":"icon","url":"https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"}]' \
+  --image "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png" \
+  --image-name "icon" \
   --convertHttpImage2Base64 true
 
 # or with a local file
 npx -y @midscene/ios@1 assert \
   --prompt "the header on screen matches the local screenshot" \
-  --images '[{"name":"header","url":"./fixtures/header.png"}]'
+  --image "./fixtures/header.png" \
+  --image-name "header"
+
+# multiple reference images — pair --image and --image-name by order
+npx -y @midscene/ios@1 assert \
+  --prompt "the screen shows both the app icon and the header" \
+  --image "./fixtures/icon.png"   --image-name "icon" \
+  --image "./fixtures/header.png" --image-name "header"
 ```
 
 ### Use a Reference Image for Precise Targeting


### PR DESCRIPTION
## Summary

- Add an `assert --images` example block to each platform SKILL.md (android / ios / harmony / browser / computer), placed right after the basic `assert --prompt` examples.
- Cover both http(s) URL and local file path forms, plus the `--convertHttpImage2Base64 true` flag.
- Each block notes **\`Requires @midscene/<platform>@1.9.0+\`** so agents pinned to older releases get a clear version pointer instead of a silent \`Unknown option \"--images\"\` failure.
- The \`vitest-midscene-e2e\` skill is intentionally left untouched: it already funnels users through \`aiAct\` rather than \`aiAssert\`.

## Upstream context

The corresponding feature lands in [web-infra-dev/midscene#2499](https://github.com/web-infra-dev/midscene/pull/2499) — it teaches the CLI / MCP \`assert\` tool to accept the same multimodal payload (\`prompt + images + convertHttpImage2Base64\`) that the JS SDK's \`agent.aiAssert\` already supports. Field names are 1:1 with the SDK; each image \`url\` may be an http(s) URL, a \`data:\` URI, or a local file path (resolved via \`preProcessImageUrl\`).

## Test plan

- [x] \`grep -n "assert.*--images" skills/**/SKILL.md\` — each platform now shows the new examples.
- [ ] Once \`@midscene/<platform>@1.9.0\` is released, re-run one of the example commands end-to-end on a real device/page to confirm the documented behavior matches the released CLI.