### PR TITLE
docs: document --deep-locate / --deep-think flags in device skills

### DIFF
--- a/skills/android-automation/SKILL.md
+++ b/skills/android-automation/SKILL.md
@@ -230,6 +230,26 @@ npx -y @midscene/android@1 act --prompt "fill in the username field with 'testus
 npx -y @midscene/android@1 take_screenshot
 ```
 
+## Improve Precision (Deep Locate / Deep Think)
+
+Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
+
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
+
+Both trade a little speed for better results, and you can combine them.
+
+```bash
+# more accurate element location (helps act's internal locating too)
+npx -y @midscene/android@1 act --deep-locate --prompt "tap the small overflow (⋮) icon in the top-right corner"
+
+# deeper planning for a complex, multi-step act
+npx -y @midscene/android@1 act --deep-think --prompt "open Settings, go to Wi-Fi, and connect to the network named Office"
+
+# combine both
+npx -y @midscene/android@1 act --deep-locate --deep-think --prompt "fill in the signup form and tap Submit"
+```
+
 ## Troubleshooting
 
 | Problem | Solution |

--- a/skills/android-automation/SKILL.md
+++ b/skills/android-automation/SKILL.md
@@ -234,7 +234,7 @@ npx -y @midscene/android@1 take_screenshot
 
 Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
 
-- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`.
 - `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
 
 Both trade a little speed for better results, and you can combine them.

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -303,6 +303,28 @@ npx -y @midscene/web@1 act --prompt "fill in the email field with 'user@example.
 npx -y @midscene/web@1 take_screenshot
 ```
 
+## Improve Precision (Deep Locate / Deep Think)
+
+Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
+
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
+
+Both trade a little speed for better results, and you can combine them.
+
+```bash
+# more accurate element location (helps act's internal locating too)
+npx -y @midscene/web@1 act --deep-locate --prompt "click the tiny gear icon in the top-right toolbar"
+
+# deeper planning for a complex, multi-step act
+npx -y @midscene/web@1 act --deep-think --prompt "complete the multi-step checkout form"
+
+# combine both
+npx -y @midscene/web@1 act --deep-locate --deep-think --prompt "open the settings menu, go to Preferences, and enable dark mode"
+```
+
+In CDP or Bridge mode, keep your usual `--cdp` / `--bridge` flags alongside these.
+
 ## Troubleshooting
 
 ### Connection Failures

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -307,7 +307,7 @@ npx -y @midscene/web@1 take_screenshot
 
 Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
 
-- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`.
 - `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
 
 Both trade a little speed for better results, and you can combine them.

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -272,6 +272,26 @@ npx -y @midscene/computer@1 take_screenshot
 ```
 
 
+## Improve Precision (Deep Locate / Deep Think)
+
+Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
+
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
+
+Both trade a little speed for better results, and you can combine them.
+
+```bash
+# more accurate element location (helps act's internal locating too)
+npx -y @midscene/computer@1 act --deep-locate --prompt "click the tiny red close button in the top-left of the window"
+
+# deeper planning for a complex, multi-step act
+npx -y @midscene/computer@1 act --deep-think --prompt "open the Export dialog, choose PDF, and save it to the Desktop"
+
+# combine both
+npx -y @midscene/computer@1 act --deep-locate --deep-think --prompt "open Preferences and switch to the Advanced tab"
+```
+
 ## Troubleshooting
 
 ### macOS: Accessibility Permission Denied

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -276,7 +276,7 @@ npx -y @midscene/computer@1 take_screenshot
 
 Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
 
-- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`.
 - `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
 
 Both trade a little speed for better results, and you can combine them.

--- a/skills/harmony-automation/SKILL.md
+++ b/skills/harmony-automation/SKILL.md
@@ -259,6 +259,26 @@ npx -y @midscene/harmony@1 take_screenshot
 | Browser | com.huawei.hmos.browser |
 | Weather | com.huawei.hmos.weather |
 
+## Improve Precision (Deep Locate / Deep Think)
+
+Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
+
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
+
+Both trade a little speed for better results, and you can combine them.
+
+```bash
+# more accurate element location (helps act's internal locating too)
+npx -y @midscene/harmony@1 act --deep-locate --prompt "tap the small back arrow in the top-left corner"
+
+# deeper planning for a complex, multi-step act
+npx -y @midscene/harmony@1 act --deep-think --prompt "scroll the settings list, open About device, and find the system version"
+
+# combine both
+npx -y @midscene/harmony@1 act --deep-locate --deep-think --prompt "open Settings, go to Wi-Fi, and toggle it on"
+```
+
 ## Troubleshooting
 
 | Problem | Solution |

--- a/skills/harmony-automation/SKILL.md
+++ b/skills/harmony-automation/SKILL.md
@@ -263,7 +263,7 @@ npx -y @midscene/harmony@1 take_screenshot
 
 Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
 
-- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`.
 - `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
 
 Both trade a little speed for better results, and you can combine them.

--- a/skills/ios-automation/SKILL.md
+++ b/skills/ios-automation/SKILL.md
@@ -230,6 +230,26 @@ npx -y @midscene/ios@1 act --prompt "fill in the username field with 'testuser' 
 npx -y @midscene/ios@1 take_screenshot
 ```
 
+## Improve Precision (Deep Locate / Deep Think)
+
+Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
+
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
+
+Both trade a little speed for better results, and you can combine them.
+
+```bash
+# more accurate element location (helps act's internal locating too)
+npx -y @midscene/ios@1 act --deep-locate --prompt "tap the small back chevron in the top-left corner"
+
+# deeper planning for a complex, multi-step act
+npx -y @midscene/ios@1 act --deep-think --prompt "complete the multi-step signup form and submit"
+
+# combine both
+npx -y @midscene/ios@1 act --deep-locate --deep-think --prompt "open Settings, go to Display & Brightness, and turn on Dark Mode"
+```
+
 ## Troubleshooting
 
 ### WebDriverAgent Not Running

--- a/skills/ios-automation/SKILL.md
+++ b/skills/ios-automation/SKILL.md
@@ -234,7 +234,7 @@ npx -y @midscene/ios@1 take_screenshot
 
 Two optional global flags help when Midscene struggles with a task. Put them anywhere in the command (before or after the sub-command); once set, the relevant operations use them by default, so you don't pass a per-call parameter.
 
-- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`. **Requires a visual-language (VL) model.**
+- `--deep-locate` — spends an extra round of visual reasoning to pinpoint the target element. Use it when an action interacts with the wrong spot (location drift / offset). It applies to every operation that locates an element, including `tap --locate` and the locating that happens inside `act`.
 - `--deep-think` — plans `act` with deeper reasoning (richer context and sub-goal decomposition). Use it for complex, multi-step `act` instructions; it only affects planning.
 
 Both trade a little speed for better results, and you can combine them.


### PR DESCRIPTION
## Summary

Document the new global precision flags in the five device skills so agents can recover from **location drift / offset** and improve `act` planning.

A new **Improve Precision (Deep Locate / Deep Think)** section is added to:

- `skills/browser`
- `skills/android-automation`
- `skills/ios-automation`
- `skills/computer-automation`
- `skills/harmony-automation`

Each section explains:

- `--deep-locate` — extra visual-reasoning pass for element location; fixes tap/interact landing on the wrong spot. Applies to `tap --locate` and the locating inside `act`. **Requires a VL model.**
- `--deep-think` — deeper planning for complex, multi-step `act` instructions.
- Both are global (placeable anywhere in the command), combinable, and become the default once set.

Examples use each platform's own package (`@midscene/web@1`, `@midscene/android@1`, …).

## ⚠️ Merge dependency

These flags do **not** exist in any published `@midscene/*` release yet. They are added by web-infra-dev/midscene#2599, which is still open.

**Do not merge this PR until #2599 is merged AND released to npm.** Merging earlier would ship docs that tell agents to pass `--deep-locate` / `--deep-think`, which older CLIs reject as an unknown option.

Recommended order: merge & release web-infra-dev/midscene#2599 → then merge this PR.

## Context

These flags are supported by the device CLIs (and MCP) via the shared tool definitions — see web-infra-dev/midscene#2446. `vitest-midscene-e2e` is intentionally untouched: it drives Midscene through the agent API (`deepLocate` option), not CLI flags.

> Note: no minimum version is pinned per maintainer preference; the flags ship with the corresponding `@midscene/*` release.