### PR TITLE
docs: document assert --message flag across automation skills

### DIFF
--- a/skills/android-automation/SKILL.md
+++ b/skills/android-automation/SKILL.md
@@ -148,6 +148,14 @@ npx -y @midscene/android@1 assert --device-id emulator-5554 --prompt "the app sh
 npx -y @midscene/android@1 assert --device-id emulator-5554 --use-scrcpy --prompt "the app shows a successful login message"
 ```
 
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/android@1.9.2+`.
+
+```bash
+npx -y @midscene/android@1 assert \
+  --prompt "the order confirmation screen is visible" \
+  --message "the order should be confirmed after tapping Pay"
+```
+
 When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/android@1.9.0+`.
 
 ```bash

--- a/skills/android-automation/SKILL.md
+++ b/skills/android-automation/SKILL.md
@@ -148,7 +148,7 @@ npx -y @midscene/android@1 assert --device-id emulator-5554 --prompt "the app sh
 npx -y @midscene/android@1 assert --device-id emulator-5554 --use-scrcpy --prompt "the app shows a successful login message"
 ```
 
-By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/android@1.9.2+`.
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs.
 
 ```bash
 npx -y @midscene/android@1 assert \

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -200,6 +200,14 @@ npx -y @midscene/web@1 assert --cdp ws://127.0.0.1:9222/devtools/browser --promp
 npx -y @midscene/web@1 --bridge assert --prompt "the profile page shows the user's avatar"
 ```
 
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/web@1.9.2+`.
+
+```bash
+npx -y @midscene/web@1 assert \
+  --prompt "the checkout page shows an order confirmation" \
+  --message "the order should be confirmed after clicking Pay"
+```
+
 When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/web@1.9.0+`.
 
 ```bash

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -200,7 +200,7 @@ npx -y @midscene/web@1 assert --cdp ws://127.0.0.1:9222/devtools/browser --promp
 npx -y @midscene/web@1 --bridge assert --prompt "the profile page shows the user's avatar"
 ```
 
-By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/web@1.9.2+`.
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs.
 
 ```bash
 npx -y @midscene/web@1 assert \

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -170,6 +170,14 @@ npx -y @midscene/computer@1 assert --prompt "the active window shows a saved con
 npx -y @midscene/computer@1 assert --displayId 1 --prompt "the file picker is open"
 ```
 
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/computer@1.9.2+`.
+
+```bash
+npx -y @midscene/computer@1 assert \
+  --prompt "the export completed dialog is visible" \
+  --message "the export should finish after clicking Save"
+```
+
 When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/computer@1.9.0+`.
 
 ```bash

--- a/skills/computer-automation/SKILL.md
+++ b/skills/computer-automation/SKILL.md
@@ -170,7 +170,7 @@ npx -y @midscene/computer@1 assert --prompt "the active window shows a saved con
 npx -y @midscene/computer@1 assert --displayId 1 --prompt "the file picker is open"
 ```
 
-By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/computer@1.9.2+`.
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs.
 
 ```bash
 npx -y @midscene/computer@1 assert \

--- a/skills/harmony-automation/SKILL.md
+++ b/skills/harmony-automation/SKILL.md
@@ -150,6 +150,14 @@ npx -y @midscene/harmony@1 assert --prompt "the settings screen shows Wi-Fi and 
 npx -y @midscene/harmony@1 assert --deviceId 0123456789ABCDEF --prompt "the app shows a successful login message"
 ```
 
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/harmony@1.9.2+`.
+
+```bash
+npx -y @midscene/harmony@1 assert \
+  --prompt "the order confirmation screen is visible" \
+  --message "the order should be confirmed after tapping Pay"
+```
+
 When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/harmony@1.9.0+`.
 
 ```bash

--- a/skills/harmony-automation/SKILL.md
+++ b/skills/harmony-automation/SKILL.md
@@ -150,7 +150,7 @@ npx -y @midscene/harmony@1 assert --prompt "the settings screen shows Wi-Fi and 
 npx -y @midscene/harmony@1 assert --deviceId 0123456789ABCDEF --prompt "the app shows a successful login message"
 ```
 
-By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/harmony@1.9.2+`.
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs.
 
 ```bash
 npx -y @midscene/harmony@1 assert \

--- a/skills/ios-automation/SKILL.md
+++ b/skills/ios-automation/SKILL.md
@@ -138,7 +138,7 @@ npx -y @midscene/ios@1 assert --prompt "there is a login button visible"
 npx -y @midscene/ios@1 assert --prompt "the settings screen shows Wi-Fi and Bluetooth options"
 ```
 
-By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/ios@1.9.2+`.
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs.
 
 ```bash
 npx -y @midscene/ios@1 assert \

--- a/skills/ios-automation/SKILL.md
+++ b/skills/ios-automation/SKILL.md
@@ -138,6 +138,14 @@ npx -y @midscene/ios@1 assert --prompt "there is a login button visible"
 npx -y @midscene/ios@1 assert --prompt "the settings screen shows Wi-Fi and Bluetooth options"
 ```
 
+By default a failed assertion throws an AI-generated reason. Pass `--message` to throw a custom error message instead, which is useful for surfacing the intended outcome in QA and CI logs. Requires `@midscene/ios@1.9.2+`.
+
+```bash
+npx -y @midscene/ios@1 assert \
+  --prompt "the order confirmation screen is visible" \
+  --message "the order should be confirmed after tapping Pay"
+```
+
 When the assertion needs to compare against a reference image (icon, logo, screenshot), pass `--image` for the URL/path and `--image-name` for its display name. Each `--image` may be an http(s) link, a `data:` URI, or a local file path. Repeat both flags in matching order when you need to attach more than one image. Add `--convertHttpImage2Base64 true` when the model cannot reach the URL directly. Requires `@midscene/ios@1.9.0+`.
 
 ```bash


### PR DESCRIPTION
## Summary

Documents the new `--message` flag for the `assert` command across all
automation skills (iOS, Android, Web, Computer, HarmonyOS).

The `assert` CLI/MCP tool previously exposed only `--prompt` (and image
flags). Upstream [web-infra-dev/midscene#2604](https://github.com/web-infra-dev/midscene/pull/2604)
(closing issue #2351) wires the optional `--message` flag through to
`aiAssert`'s second argument, so a failed assertion can throw a custom,
caller-supplied error instead of a generic AI-generated reason — useful for
QA and CI logs.

## Changes

Each affected `SKILL.md` gains a short note plus an example in the assert
section:

```bash
npx -y @midscene/<pkg>@1 assert \
  --prompt "the order confirmation screen is visible" \
  --message "the order should be confirmed after tapping Pay"
```

- `skills/ios-automation/SKILL.md`
- `skills/android-automation/SKILL.md`
- `skills/browser/SKILL.md`
- `skills/computer-automation/SKILL.md`
- `skills/harmony-automation/SKILL.md`
