### PR TITLE
docs(skills): document CDP request headers

### DIFF
--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -126,6 +126,28 @@ npx -y @midscene/web@1 take_screenshot --cdp ws://127.0.0.1:9222/devtools/browse
 npx -y @midscene/web@1 disconnect --cdp ws://127.0.0.1:9222/devtools/browser
 ```
 
+### Custom HTTP Headers in CDP Mode
+
+When the user needs custom request headers in CDP mode, such as routing requests to a PPE environment, pass them as a JSON object through `--extra-http-headers`. Use the exact header names and values supplied by the user; do not guess environment names or authentication values.
+
+Store the JSON in a shell variable so it can be reused without duplicating values. Header values must be strings:
+
+```bash
+cdp_headers='{"x-use-ppe":"1","x-tt-env":"ppe_example"}'
+
+npx -y @midscene/web@1 connect \
+  --cdp ws://127.0.0.1:9222/devtools/browser \
+  --extra-http-headers "$cdp_headers" \
+  --url https://example.com
+
+npx -y @midscene/web@1 act \
+  --cdp ws://127.0.0.1:9222/devtools/browser \
+  --extra-http-headers "$cdp_headers" \
+  --prompt "click the button"
+```
+
+Each CLI command creates a new CDP session. Pass `--extra-http-headers "$cdp_headers"` to every CDP command that may issue requests, including `connect`, `act`, and `assert`. The headers are applied before `connect --url` navigates, so the initial document request includes them. Do not print header values in task summaries, and avoid putting sensitive authentication values directly in shell history.
+
 ### Important notes for CDP mode
 
 - The browser is managed externally — `disconnect` releases the connection but does NOT close the browser. There is no `close` command in CDP mode.

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -128,25 +128,23 @@ npx -y @midscene/web@1 disconnect --cdp ws://127.0.0.1:9222/devtools/browser
 
 ### Custom HTTP Headers in CDP Mode
 
-When the user needs custom request headers in CDP mode, such as routing requests to a PPE environment, pass them as a JSON object through `--extra-http-headers`. Use the exact header names and values supplied by the user; do not guess environment names or authentication values.
-
-Store the JSON in a shell variable so it can be reused without duplicating values. Header values must be strings:
+When the user needs custom request headers in CDP mode, such as routing requests to a PPE environment, pass each header through a separate `--extra-http-header 'Name:Value'` option. Repeat the option to send multiple headers. Use the exact header names and values supplied by the user; do not guess environment names or authentication values.
 
 ```bash
-cdp_headers='{"x-use-ppe":"1","x-tt-env":"ppe_example"}'
-
 npx -y @midscene/web@1 connect \
   --cdp ws://127.0.0.1:9222/devtools/browser \
-  --extra-http-headers "$cdp_headers" \
+  --extra-http-header 'x-use-ppe:1' \
+  --extra-http-header 'x-tt-env:ppe_example' \
   --url https://example.com
 
 npx -y @midscene/web@1 act \
   --cdp ws://127.0.0.1:9222/devtools/browser \
-  --extra-http-headers "$cdp_headers" \
+  --extra-http-header 'x-use-ppe:1' \
+  --extra-http-header 'x-tt-env:ppe_example' \
   --prompt "click the button"
 ```
 
-Each CLI command creates a new CDP session. Pass `--extra-http-headers "$cdp_headers"` to every CDP command that may issue requests, including `connect`, `act`, and `assert`. The headers are applied before `connect --url` navigates, so the initial document request includes them. Do not print header values in task summaries, and avoid putting sensitive authentication values directly in shell history.
+Each CLI command creates a new CDP session. Repeat every required `--extra-http-header 'Name:Value'` option on each CDP command that may issue requests, including `connect`, `act`, and `assert`. Split each entry at the first colon, so values may contain additional colons. The headers are applied before `connect --url` navigates, so the initial document request includes them. Do not print header values in task summaries, and avoid putting sensitive authentication values directly in shell history.
 
 ### Important notes for CDP mode
 


### PR DESCRIPTION
## Summary

- document the repeatable `--extra-http-header 'Name:Value'` syntax for CDP request headers
- show multiple PPE headers as separate CLI options instead of a JSON object
- clarify that every request-producing CDP command must repeat the required options and that values may contain additional colons

## Validation

- `node scripts/check-skill-description-length.mjs`
- `git diff --check`

## Dependency

- Requires web-infra-dev/midscene#2862.
