### PR TITLE
docs(skills): require upload directory authorization

### DIFF
--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -184,19 +184,15 @@ npx -y @midscene/web@1 act --prompt "scroll down and click the Submit button"
 npx -y @midscene/web@1 act --prompt "click the country dropdown and select Japan"
 ```
 
-### Upload local files
+### Upload Files
 
-Include the exact local file path in the `act` prompt. Use an absolute path. Relative paths resolve from the directory where you run the command.
+When a prompt asks Midscene to upload files, `act` requires an explicit `--file-chooser-allowed-dir`. Use the smallest directory that contains the test fixtures; do not grant the project root or a home directory. Refer to files by paths relative to that directory in the prompt.
 
 ```bash
-avatar_path=/absolute/path/to/avatar.png
 npx -y @midscene/web@1 act \
-  --prompt "click the Upload avatar button and upload $avatar_path"
+  --file-chooser-allowed-dir ./fixtures \
+  --prompt "click the upload button and upload avatar.png"
 ```
-
-For multiple uploads, pair each path with the action that opens its file chooser. Midscene replaces the previous file chooser configuration before the next upload.
-
-This works in Puppeteer, CDP, and Bridge modes.
 
 ### Assert Current Page State
 

--- a/skills/vitest-midscene-e2e/SKILL.md
+++ b/skills/vitest-midscene-e2e/SKILL.md
@@ -79,21 +79,16 @@ await ctx.agent.aiAct('verify the page shows "Login successful"');
 await ctx.agent.aiAct('verify the error message is visible');
 ```
 
-#### Upload local files in Web tests
+### Prompt-driven File Uploads (Web only)
 
-Prompt-based file uploads work only with the Web agent. Resolve each file path before adding it to the prompt.
+When an `aiAct` prompt asks Midscene to upload files, pass `fileChooserAllowedDir` explicitly. Use the smallest directory containing that test case's fixtures, and refer to files relative to it in the prompt. Do not use the project root or a home directory. Replace `./fixtures` below with the fixture directory relative to the test process working directory.
 
 ```typescript
-import { resolve } from 'node:path';
-
-const avatarPath = resolve('e2e/fixtures/avatar.png');
-
 await ctx.agent.aiAct(
-  `click the "Upload avatar" button and upload ${avatarPath}`,
+  'click the upload button and upload avatar.png',
+  { fileChooserAllowedDir: './fixtures' },
 );
 ```
-
-For multiple uploads in one `aiAct`, pair each path with the action that opens its file chooser. Do not combine prompt paths with `fileChooserAccept`. A later planned upload can replace the configured files.
 
 **Phase splitting:** If the task prompt is too long or covers multiple distinct stages, split it into separate `aiAct` calls — one per phase. Each phase should be a self-contained logical step, and all phases combined must match the user's original intent.
 


### PR DESCRIPTION
## Summary

- document explicit upload-directory authorization for browser CLI usage
- document `fileChooserAllowedDir` for Vitest prompt-driven uploads

## Validation

- `git diff --check`